### PR TITLE
Toggle style index not set correctly

### DIFF
--- a/lua/neomodern/highlights.lua
+++ b/lua/neomodern/highlights.lua
@@ -66,7 +66,7 @@ hl.common = {
   NormalFloat = { fg = c.fg, bg = config.transparent and c.none or c.float },
   Pmenu = { fg = c.fg, bg = c.visual },
   PmenuSbar = { fg = c.none, bg = c.visual },
-  PmenuSel = { fg = c.type },
+  PmenuSel = { bg = c.float },
   PmenuThumb = { fg = c.none, bg = c.visual },
   Question = { fg = c.constant },
   QuickFixLine = { fg = c.func, fmt = "underline" },

--- a/lua/neomodern/init.lua
+++ b/lua/neomodern/init.lua
@@ -102,7 +102,7 @@ function M.setup(opts)
     end
   end
   if vim.g.neomodern_config.toggle_style_key then
-    vim.api.nvim_set_keymap(
+    vim.keymap.set(
       "n",
       vim.g.neomodern_config.toggle_style_key,
       '<cmd>lua require("neomodern").toggle()<cr>',

--- a/lua/neomodern/init.lua
+++ b/lua/neomodern/init.lua
@@ -93,7 +93,11 @@ function M.setup(opts)
     vim.g.neomodern_config =
       vim.tbl_deep_extend("keep", vim.g.neomodern_config or {}, default_config)
     M.set_options("loaded", true)
-    M.set_options("toggle_style_index", 0)
+    for i, v in ipairs(vim.g.neomodern_config.toggle_style_list) do
+      if v == vim.g.neomodern_config.style then
+        M.set_options("toggle_style_index", i)
+      end
+    end
   end
   if opts then
     vim.g.neomodern_config = vim.tbl_deep_extend("force", vim.g.neomodern_config, opts)


### PR DESCRIPTION
The toggle style index is being initially set to 0. If iceclimber is set as the theme than the toggle style keymap will need to be pressed twice. Instead, the toggle style index should be set to the index for the selected theme.