### PR TITLE
Fix util require

### DIFF
--- a/lua/neomodern/highlights/syntax.lua
+++ b/lua/neomodern/highlights/syntax.lua
@@ -3,7 +3,7 @@ local M = {}
 function M.get()
     ---@type neomodern.Config
     local Config = require("neomodern").options()
-    local Util = require("neomodern.Util")
+    local Util = require("neomodern.util")
     ---@type neomodern.Theme
     local c = require("neomodern.palette").get(Config.theme, Config.variant)
     local hl = {}


### PR DESCRIPTION
The latest commit caused Neomodern to fail to run with the error message: `"module 'neomodern.Util' not found"`. 

 This PR updates `syntax.lua` to use `neomodern.util`.