### PR TITLE
fix foot terminal configuration template

### DIFF
--- a/extras/foot/gyokuro.ini
+++ b/extras/foot/gyokuro.ini
@@ -3,10 +3,8 @@
 # upstream: https://github.com/cdmill/neomodern.nvim/raw/main/extras/foot/gyokuro.ini
 # author: Casey Miller
 
-[cursor]
-color=bbbac1 323334
-
 [colors]
+cursor=bbbac1 323334
 foreground=bbbac1
 background=1b1c1d
 # alternate, darker background=161617

--- a/extras/foot/hojicha.ini
+++ b/extras/foot/hojicha.ini
@@ -3,10 +3,8 @@
 # upstream: https://github.com/cdmill/neomodern.nvim/raw/main/extras/foot/hojicha.ini
 # author: Casey Miller
 
-[cursor]
-color=adacac 333333
-
 [colors]
+cursor=adacac 333333
 foreground=adacac
 background=161616
 # alternate, darker background=111111

--- a/extras/foot/iceclimber.ini
+++ b/extras/foot/iceclimber.ini
@@ -3,10 +3,8 @@
 # upstream: https://github.com/cdmill/neomodern.nvim/raw/main/extras/foot/iceclimber.ini
 # author: Casey Miller
 
-[cursor]
-color=bbbac1 2a2a31
-
 [colors]
+cursor=bbbac1 2a2a31
 foreground=bbbac1
 background=171719
 # alternate, darker background=111113

--- a/extras/foot/roseprime.ini
+++ b/extras/foot/roseprime.ini
@@ -3,10 +3,8 @@
 # upstream: https://github.com/cdmill/neomodern.nvim/raw/main/extras/foot/roseprime.ini
 # author: Casey Miller
 
-[cursor]
-color=adadcc 262830
-
 [colors]
+cursor=adadcc 262830
 foreground=adadcc
 background=121315
 # alternate, darker background=111111

--- a/lua/neomodern/extras/templates/foot.lua
+++ b/lua/neomodern/extras/templates/foot.lua
@@ -21,10 +21,8 @@ function M.generate(colors, info)
 # upstream: ${upstream}
 # author: Casey Miller
 
-[cursor]
-color=${fg} ${visual}
-
 [colors]
+cursor=${fg} ${visual}
 foreground=${fg}
 background=${bg}
 # alternate, darker background=${alt_bg}


### PR DESCRIPTION
cursor.color deprecated for foot terminal. this pr replaces foot template to use colors.cursor instead.

foot configuration reference:
https://codeberg.org/dnkl/foot/src/commit/b78cc92322dd2ae431dbbb70bc681b4d603d844d/foot.ini#L112